### PR TITLE
Add hook assist with predictive release

### DIFF
--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -700,6 +700,8 @@ MACRO_CONFIG_STR(SvConnLoggingServer, sv_conn_logging_server, 128, "", CFGFLAG_S
 
 MACRO_CONFIG_INT(ClUnpredictedShadow, cl_unpredicted_shadow, 0, -1, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show unpredicted shadow tee (0 = off, 1 = on, -1 = don't even show in debug mode)")
 MACRO_CONFIG_INT(ClPredictFreeze, cl_predict_freeze, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Predict freeze tiles (0 = off, 1 = on, 2 = partial (allow a small amount of movement in freeze)")
+MACRO_CONFIG_INT(ClHookAssist, cl_hook_assist, 0, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Automatically release the hook when a freeze is predicted")
+MACRO_CONFIG_INT(ClHookAssistTicks, cl_hook_assist_ticks, 3, 1, 50, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Number of prediction ticks used by hook assist")
 MACRO_CONFIG_INT(ClShowNinja, cl_show_ninja, 1, 0, 1, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show ninja skin")
 MACRO_CONFIG_INT(ClShowHookCollOther, cl_show_hook_coll_other, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show other players' hook collision line (2 to always show)")
 MACRO_CONFIG_INT(ClShowHookCollOwn, cl_show_hook_coll_own, 1, 0, 2, CFGFLAG_CLIENT | CFGFLAG_SAVE, "Show own players' hook collision line (2 to always show)")

--- a/src/game/client/components/controls.cpp
+++ b/src/game/client/components/controls.cpp
@@ -2,6 +2,8 @@
 /* If you are missing that file, acquire a complete release at teeworlds.com.                */
 #include <base/math.h>
 
+#include <algorithm>
+
 #include <engine/client.h>
 #include <engine/shared/config.h>
 
@@ -10,6 +12,8 @@
 #include <game/client/components/menus.h>
 #include <game/client/components/scoreboard.h>
 #include <game/client/gameclient.h>
+#include <game/client/prediction/entities/character.h>
+#include <game/client/prediction/gameworld.h>
 #include <game/collision.h>
 
 #include <base/vmath.h>
@@ -283,24 +287,26 @@ int CControls::SnapInput(int *pData)
 			m_aInputData[!g_Config.m_ClDummy] = *pDummyInput;
 		}
 
-		if(g_Config.m_ClDummyControl)
-		{
-			CNetObj_PlayerInput *pDummyInput = &GameClient()->m_DummyInput;
-			pDummyInput->m_Jump = g_Config.m_ClDummyJump;
+                if(g_Config.m_ClDummyControl)
+                {
+                        CNetObj_PlayerInput *pDummyInput = &GameClient()->m_DummyInput;
+                        pDummyInput->m_Jump = g_Config.m_ClDummyJump;
 
-			if(g_Config.m_ClDummyFire)
-				pDummyInput->m_Fire = g_Config.m_ClDummyFire;
-			else if((pDummyInput->m_Fire & 1) != 0)
-				pDummyInput->m_Fire++;
+                        if(g_Config.m_ClDummyFire)
+                                pDummyInput->m_Fire = g_Config.m_ClDummyFire;
+                        else if((pDummyInput->m_Fire & 1) != 0)
+                                pDummyInput->m_Fire++;
 
-			pDummyInput->m_Hook = g_Config.m_ClDummyHook;
-		}
+                        pDummyInput->m_Hook = g_Config.m_ClDummyHook;
+                }
 
-		// stress testing
+                HookAssist();
+
+                // stress testing
 #ifdef CONF_DEBUG
-		if(g_Config.m_DbgStress)
-		{
-			float t = Client()->LocalTime();
+                if(g_Config.m_DbgStress)
+                {
+                        float t = Client()->LocalTime();
 			mem_zero(&m_aInputData[g_Config.m_ClDummy], sizeof(m_aInputData[0]));
 
 			m_aInputData[g_Config.m_ClDummy].m_Direction = ((int)t / 2) & 1;
@@ -479,36 +485,95 @@ float CControls::GetMaxMouseDistance() const
 
 bool CControls::CheckNewInput()
 {
-	CNetObj_PlayerInput TestInput = m_aInputData[g_Config.m_ClDummy];
-	TestInput.m_Direction = 0;
-	if(m_aInputDirectionLeft[g_Config.m_ClDummy] && !m_aInputDirectionRight[g_Config.m_ClDummy])
-		TestInput.m_Direction = -1;
-	if(!m_aInputDirectionLeft[g_Config.m_ClDummy] && m_aInputDirectionRight[g_Config.m_ClDummy])
-		TestInput.m_Direction = 1;
+        CNetObj_PlayerInput TestInput = m_aInputData[g_Config.m_ClDummy];
+        TestInput.m_Direction = 0;
+        if(m_aInputDirectionLeft[g_Config.m_ClDummy] && !m_aInputDirectionRight[g_Config.m_ClDummy])
+                TestInput.m_Direction = -1;
+        if(!m_aInputDirectionLeft[g_Config.m_ClDummy] && m_aInputDirectionRight[g_Config.m_ClDummy])
+                TestInput.m_Direction = 1;
 
-	bool NewInput = false;
-	if(m_FastInput.m_Direction != TestInput.m_Direction)
-		NewInput = true;
-	if(m_FastInput.m_Hook != TestInput.m_Hook)
-		NewInput = true;
-	if(m_FastInput.m_Fire != TestInput.m_Fire)
-		NewInput = true;
-	if(m_FastInput.m_Jump != TestInput.m_Jump)
-		NewInput = true;
-	if(m_FastInput.m_NextWeapon != TestInput.m_NextWeapon)
-		NewInput = true;
-	if(m_FastInput.m_PrevWeapon != TestInput.m_PrevWeapon)
-		NewInput = true;
-	if(m_FastInput.m_WantedWeapon != TestInput.m_WantedWeapon)
-		NewInput = true;
+        bool NewInput = false;
+        if(m_FastInput.m_Direction != TestInput.m_Direction)
+                NewInput = true;
+        if(m_FastInput.m_Hook != TestInput.m_Hook)
+                NewInput = true;
+        if(m_FastInput.m_Fire != TestInput.m_Fire)
+                NewInput = true;
+        if(m_FastInput.m_Jump != TestInput.m_Jump)
+                NewInput = true;
+        if(m_FastInput.m_NextWeapon != TestInput.m_NextWeapon)
+                NewInput = true;
+        if(m_FastInput.m_PrevWeapon != TestInput.m_PrevWeapon)
+                NewInput = true;
+        if(m_FastInput.m_WantedWeapon != TestInput.m_WantedWeapon)
+                NewInput = true;
 
-	if(g_Config.m_ClSubTickAiming)
-	{
-		TestInput.m_TargetX = (int)m_aMousePos[g_Config.m_ClDummy].x;
-		TestInput.m_TargetY = (int)m_aMousePos[g_Config.m_ClDummy].y;
-	}
+        if(g_Config.m_ClSubTickAiming)
+        {
+                TestInput.m_TargetX = (int)m_aMousePos[g_Config.m_ClDummy].x;
+                TestInput.m_TargetY = (int)m_aMousePos[g_Config.m_ClDummy].y;
+        }
 
-	m_FastInput = TestInput;
+        m_FastInput = TestInput;
 
-	return NewInput;
+        return NewInput;
+}
+
+void CControls::HookAssist()
+{
+        if(!g_Config.m_ClHookAssist)
+                return;
+
+        if(!GameClient()->Predict())
+                return;
+
+        const int LocalDummy = g_Config.m_ClDummy;
+        const int LocalClientId = GameClient()->m_aLocalIds[LocalDummy];
+        if(LocalClientId < 0)
+                return;
+
+        if(m_aInputData[LocalDummy].m_Hook == 0)
+                return;
+
+        const int CheckTicks = std::clamp(g_Config.m_ClHookAssistTicks, 1, 50);
+        if(PredictFreeze(LocalClientId, m_aInputData[LocalDummy], CheckTicks))
+        {
+                m_aInputData[LocalDummy].m_Hook = 0;
+        }
+}
+
+bool CControls::PredictFreeze(int LocalClientId, const CNetObj_PlayerInput &Input, int Ticks)
+{
+        if(Ticks <= 0)
+                return false;
+
+        if(!GameClient()->Predict())
+                return false;
+
+        CGameWorld &World = GameClient()->m_ExtraPredictedWorld;
+        World.CopyWorldClean(&GameClient()->m_PredictedWorld);
+
+        CCharacter *pChar = World.GetCharacterById(LocalClientId);
+        if(!pChar)
+                return false;
+
+        CNetObj_PlayerInput SimulatedInput = Input;
+        SimulatedInput.m_PlayerFlags &= ~(PLAYERFLAG_CHATTING | PLAYERFLAG_IN_MENU | PLAYERFLAG_SCOREBOARD);
+        SimulatedInput.m_PlayerFlags |= PLAYERFLAG_PLAYING;
+
+        for(int i = 0; i < Ticks; ++i)
+        {
+                pChar->OnPredictedInput(&SimulatedInput);
+                World.m_GameTick++;
+                World.Tick();
+
+                pChar = World.GetCharacterById(LocalClientId);
+                if(!pChar)
+                        return false;
+
+                if(pChar->m_FreezeTime > 0 || pChar->Core()->m_IsInFreeze)
+                        return true;
+        }
+
+        return false;
 }

--- a/src/game/client/components/controls.h
+++ b/src/game/client/components/controls.h
@@ -48,9 +48,12 @@ public:
 	bool CheckNewInput();
 
 private:
-	static void ConKeyInputState(IConsole::IResult *pResult, void *pUserData);
-	static void ConKeyInputCounter(IConsole::IResult *pResult, void *pUserData);
-	static void ConKeyInputSet(IConsole::IResult *pResult, void *pUserData);
-	static void ConKeyInputNextPrevWeapon(IConsole::IResult *pResult, void *pUserData);
+        static void ConKeyInputState(IConsole::IResult *pResult, void *pUserData);
+        static void ConKeyInputCounter(IConsole::IResult *pResult, void *pUserData);
+        static void ConKeyInputSet(IConsole::IResult *pResult, void *pUserData);
+        static void ConKeyInputNextPrevWeapon(IConsole::IResult *pResult, void *pUserData);
+
+        void HookAssist();
+        bool PredictFreeze(int LocalClientId, const CNetObj_PlayerInput &Input, int Ticks);
 };
 #endif

--- a/src/game/client/components/menus_settings.cpp
+++ b/src/game/client/components/menus_settings.cpp
@@ -2936,14 +2936,33 @@ void CMenus::RenderSettingsAppearance(CUIRect MainView)
 
 		GameClient()->m_NamePlates.RenderNamePlatePreview(Position, Dummy);
 	}
-	else if(s_CurTab == APPEARANCE_TAB_HOOK_COLLISION)
-	{
-		MainView.VSplitMid(&LeftView, &RightView, MarginBetweenViews);
+        else if(s_CurTab == APPEARANCE_TAB_HOOK_COLLISION)
+        {
+                MainView.VSplitMid(&LeftView, &RightView, MarginBetweenViews);
 
-		// ***** Hookline ***** //
-		Ui()->DoLabel_AutoLineSize(Localize("Hook collision line"), HeadlineFontSize,
-			TEXTALIGN_ML, &LeftView, HeadlineHeight);
-		LeftView.HSplitTop(MarginSmall, nullptr, &LeftView);
+                // ***** Hook assist ***** //
+                Ui()->DoLabel_AutoLineSize(Localize("Hook assist"), HeadlineFontSize,
+                        TEXTALIGN_ML, &LeftView, HeadlineHeight);
+                LeftView.HSplitTop(MarginSmall, nullptr, &LeftView);
+
+                LeftView.HSplitTop(LineSize, &Button, &LeftView);
+                if(DoButton_CheckBox(&g_Config.m_ClHookAssist, Localize("Automatically release hook near freeze"), g_Config.m_ClHookAssist, &Button))
+                {
+                        g_Config.m_ClHookAssist = g_Config.m_ClHookAssist ? 0 : 1;
+                }
+
+                if(g_Config.m_ClHookAssist)
+                {
+                        LeftView.HSplitTop(LineSize * 2.0f, &Button, &LeftView);
+                        Ui()->DoScrollbarOption(&g_Config.m_ClHookAssistTicks, &g_Config.m_ClHookAssistTicks, &Button, Localize("Hook assist prediction ticks"), 1, 50, &CUi::ms_LinearScrollbarScale, CUi::SCROLLBAR_OPTION_MULTILINE);
+                }
+
+                LeftView.HSplitTop(MarginBetweenViews, nullptr, &LeftView);
+
+                // ***** Hookline ***** //
+                Ui()->DoLabel_AutoLineSize(Localize("Hook collision line"), HeadlineFontSize,
+                        TEXTALIGN_ML, &LeftView, HeadlineHeight);
+                LeftView.HSplitTop(MarginSmall, nullptr, &LeftView);
 
 		// General hookline settings
 		LeftView.HSplitTop(LineSize, &Button, &LeftView);


### PR DESCRIPTION
## Summary
- add a hook assist prediction routine that releases the hook when an imminent freeze is detected
- expose new hook assist configuration values so players can enable the feature and tune prediction ticks in the options menu

## Testing
- `cmake -S . -B build` *(fails: missing `glslangValidator` in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da24d88794832cae11ca7b50e8d340